### PR TITLE
Use devsec hardening collection

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -13,6 +13,9 @@
     docker: false
     docker_users: []
 
+  collections:
+    - devsec.hardening
+
   roles:
     - role: oefenweb.fail2ban
       become: yes
@@ -21,7 +24,7 @@
           - name: sshd
             maxretry: 5
             bantime: 1h
-    - role: dev-sec.ssh-hardening
+    - role: devsec.hardening.ssh_hardening
       become: yes
       vars:
         ssh_server_password_login: false
@@ -32,7 +35,7 @@
         sftp_enabled: true
         ssh_print_last_log: true
       when: not totp
-    - role: dev-sec.ssh-hardening
+    - role: devsec.hardening.ssh_hardening
       become: yes
       vars:
         ssh_server_password_login: false

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -1,5 +1,8 @@
 ---
-- src: dev-sec.ssh-hardening
-- src: geerlingguy.docker
-- src: oefenweb.fail2ban
-- src: singleplatform-eng.users
+roles:
+  - name: geerlingguy.docker
+  - name: oefenweb.fail2ban
+  - name: singleplatform-eng.users
+
+collections:
+  - name: devsec.hardening


### PR DESCRIPTION
The devsec standalone SSH hardening role has been deprecated (along with their other roles). The devsec hardening roles are now combined in a [collection](https://galaxy.ansible.com/devsec/hardening). This PR replaces the standalone role with the role from the collection.