### PR TITLE
Make terraform variables file clearer

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,29 +1,56 @@
-# Prefix prepended to all Azure resources names (resource groups, virtual
-# machines, etc.). You can set this to something easily identifiable, like the
-# name of your project, to avoid name clashes and help locate resources.
+# Prefix for all Azure resource names
+#
+# You can set this to something easily identifiable, like the name of your
+# project, to avoid name clashes and help locate resources.
+#
 # Default = "my"
+#
+# Example:
 # prefix = "project"
 
+
 # Size of virtual machine to deploy
-# (https://docs.microsoft.com/en-us/azure/virtual-machines/sizes)
+#
+# You can find details of available sizes here:
+# https://docs.microsoft.com/en-us/azure/virtual-machines/sizes
+#
 # Default = "Standard_B2s"
+#
+# Example:
 # vm_size = "Standard_DS3_v2"
 
+
 # Data disk size in GB
+#
 # If > 0 a data disk will be created and attached to the virtual machine. The
 # disk will have a single partition mounted at `/shared` and will be configured
 # so all users have read/write access to the directory and all files created in
 # it.
+#
 # Default = 0
+#
+# Example
 # data_disk_size_gb = 100
 
-# Azure region
-# (https://azure.microsoft.com/en-us/global-infrastructure/geographies/) to
-# deploy your resources to. This will have an impact on connection speed,
-# available virtual machine sizes and cost.
+
+# Azure region to deploy resources to
+#
+# You can see the Azure regions here:
+# https://azure.microsoft.com/en-us/global-infrastructure/geographies/ .  This
+# will have an impact on connection speed, available virtual machine sizes and
+# cost.
+#
 # Default = "eastus"
+#
+# Example
 # location = "uksouth"
 
-# Username of the administrator account created to manage the virtual machine through Ansible.
+
+# Administrator account username
+#
+# This account will be used to manage the virtual machine through Ansible.
+#
 # Default = "ansible_admin"
-# admin_username = "ansible_admin"
+#
+# Example
+# admin_username = "sam_spade"


### PR DESCRIPTION
This PR makes the description and presentation of the variables in the Terraform variables file clearer, similarly to how #8 changed the Ansible variables file.