### PR TITLE
Fix shared directory permissions

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -78,6 +78,16 @@
             device: "{{ data_disk.disk.dev }}1"
             fstype: ext4
 
+        - name: Mount data partition
+          become: yes
+          mount:
+            path: "/shared"
+            state: mounted
+            src: "{{ data_disk.disk.dev }}1"
+            fstype: ext4
+            opts: defaults,nofail
+            passno: "2"
+
         - name: Create group for shared work
           become: yes
           group:
@@ -93,7 +103,7 @@
             append: true
           loop: "{{ users }}"
 
-        - name: Create shared directory
+        - name: Configure shared directory
           become: yes
           file:
             path: /shared
@@ -116,16 +126,6 @@
             default: yes
             permissions: rw
             state: present
-
-        - name: Mount data partition
-          become: yes
-          mount:
-            path: "/shared"
-            state: mounted
-            src: "{{ data_disk.disk.dev }}1"
-            fstype: ext4
-            opts: defaults,nofail
-            passno: "2"
       when: data_disk_size_gb | int > 0
 
     - name: Configure TOTP authentication

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -66,7 +66,7 @@
         - name: Partition disk
           become: yes
           community.general.parted:
-            device: /dev/disk/azure/scsi1/lun2
+            device: /dev/disk/azure/scsi1/lun0
             label: gpt
             number: 1
             state: present

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -141,7 +141,7 @@ resource "azurerm_managed_disk" "disk" {
 resource "azurerm_virtual_machine_data_disk_attachment" "disk" {
   managed_disk_id    = azurerm_managed_disk.disk[count.index].id
   virtual_machine_id = azurerm_linux_virtual_machine.vm.id
-  lun                = "2"
+  lun                = "0"
   caching            = "ReadWrite"
 
   count = var.data_disk_size_gb > 0 ? 1 : 0


### PR DESCRIPTION
It seems that running the mount module after the file and acl modules overwrites the shared directory permissions if the mount is not already configured. This meant that the playbook would have to be run twice to get the correct permissions and ACLs. This PR reorders these tasks so only one run is necessary.

The LUN of the shared disk is also changed to 0.