### PR TITLE
Add tfsec CI step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,3 +95,17 @@ jobs:
 
       - name: Terraform Format
         run: terraform fmt -check -diff
+
+  tfsec:
+    name: "Check Terraform Security"
+    runs-on: ubuntu-lated
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check security
+        uses: triat/terraform-security-scan@v2.0.2
+        with:
+          tfsec_actions_comment: false
+          tfsec_actions_working_dir: ./terraform

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,3 +109,5 @@ jobs:
         with:
           tfsec_actions_comment: false
           tfsec_actions_working_dir: ./terraform
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
 
   tfsec:
     name: "Check Terraform Security"
-    runs-on: ubuntu-lated
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,6 +135,10 @@ resource "azurerm_managed_disk" "disk" {
   create_option        = "Empty"
   disk_size_gb         = var.data_disk_size_gb
 
+  encryption_settings {
+    enabled = true
+  }
+
   count = var.data_disk_size_gb > 0 ? 1 : 0
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,6 +60,7 @@ resource "azurerm_network_security_group" "nsg" {
 
 # Create SSH NSG rule
 resource "azurerm_network_security_rule" "ssh" {
+  #tfsec:ignore:AZU017
   name                        = "SSH"
   priority                    = 1001
   direction                   = "Inbound"
@@ -67,7 +68,7 @@ resource "azurerm_network_security_rule" "ssh" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefix       = "*"
+  source_address_prefix       = "*"  #tfsec:ignore:AZU001
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.rg.name
   network_security_group_name = azurerm_network_security_group.nsg.name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -68,7 +68,7 @@ resource "azurerm_network_security_rule" "ssh" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefix       = "*"  #tfsec:ignore:AZU001
+  source_address_prefix       = "*" #tfsec:ignore:AZU001
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.rg.name
   network_security_group_name = azurerm_network_security_group.nsg.name


### PR DESCRIPTION
### Summary

This PR introduces a step in the CI process which uses [tfsec](https://github.com/tfsec/tfsec) to statically assess Terraform files for security issues.


### List of changes proposed in this Pull Request
<!-- We suggest using bullets (indicated by - or *) and/or checkboxes (- [ ] unfilled, - [x] or filled). -->

- Add tfsec step to CI

### Updates

