### PR TITLE
Make fstab more robust

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -100,7 +100,7 @@
           ansible.posix.mount:
             path: "/shared"
             state: mounted
-            src: "{{ data_disk.disk.dev }}1"
+            src: /dev/disk/azure/scsi1/lun0-part1
             fstype: ext4
             opts: defaults,nofail
             passno: "2"


### PR DESCRIPTION
### Summary

Previously the ansible-constructed fstab entry used linux device names (sda, sdb, _etc._) for the shared data disk. This is fragile as these labels can change, in particular when resizing a VM.

The fstab entry now uses the label `/dev/disk/azure/scsi1/lun0-part1` which will exist after creating the partition on `lun0` which should always refer to the managed disk (as defined in terraform).

### List of changes proposed in this Pull Request
<!-- We suggest using bullets (indicated by - or *) and/or checkboxes (- [ ] unfilled, - [x] or filled). -->

- Change shared directory device from `sdx1` to `/dev/disk/azure/scsi1/lun0-part1`
