### PR TITLE
Remove redundant encryption settings block

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,10 +135,6 @@ resource "azurerm_managed_disk" "disk" {
   create_option        = "Empty"
   disk_size_gb         = var.data_disk_size_gb
 
-  encryption_settings {
-    enabled = true
-  }
-
   count = var.data_disk_size_gb > 0 ? 1 : 0
 }
 


### PR DESCRIPTION

### Summary
<!--
Describe the problem to be fixed or feature to be implemented in this Pull Request.
Please reference any related issue(s) and use fixes/closes keywords to automatically close them, if pertinent.
For example: "fixes #58", or "related to #238"
-->

Remove an encryption block as managed disks are encrypted at rest by default.

This block also caused an error as it is not needed for encryption using service-managed keys but is insufficient for using user-managed keys.

This will cause the tfsec action to fail until an update is released https://github.com/tfsec/tfsec/issues/656.
