### PR TITLE
Allow specifying inbound SSH IP range

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,7 +60,7 @@ resource "azurerm_network_security_group" "nsg" {
 
 # Create SSH NSG rule
 resource "azurerm_network_security_rule" "ssh_prefixes" {
-  count = length(var.ssh_addresses) > 1 ? 1: 0
+  count = length(var.ssh_addresses) > 1 ? 1 : 0
 
   name                        = "SSH"
   priority                    = 1001
@@ -76,7 +76,7 @@ resource "azurerm_network_security_rule" "ssh_prefixes" {
 }
 resource "azurerm_network_security_rule" "ssh_prefix" {
   #tfsec:ignore:AZU017
-  count = length(var.ssh_addresses) > 1 ? 0: 1
+  count = length(var.ssh_addresses) > 1 ? 0 : 1
 
   name                        = "SSH"
   priority                    = 1001

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -59,8 +59,9 @@ resource "azurerm_network_security_group" "nsg" {
 }
 
 # Create SSH NSG rule
-resource "azurerm_network_security_rule" "ssh" {
-  #tfsec:ignore:AZU017
+resource "azurerm_network_security_rule" "ssh_prefixes" {
+  count = length(var.ssh_addresses) > 1 ? 1: 0
+
   name                        = "SSH"
   priority                    = 1001
   direction                   = "Inbound"
@@ -68,7 +69,23 @@ resource "azurerm_network_security_rule" "ssh" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefix       = "*" #tfsec:ignore:AZU001
+  source_address_prefixes     = var.ssh_addresses #tfsec:ignore:AZU001
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
+}
+resource "azurerm_network_security_rule" "ssh_prefix" {
+  #tfsec:ignore:AZU017
+  count = length(var.ssh_addresses) > 1 ? 0: 1
+
+  name                        = "SSH"
+  priority                    = 1001
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = var.ssh_addresses[0] #tfsec:ignore:AZU001
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.rg.name
   network_security_group_name = azurerm_network_security_group.nsg.name

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -20,6 +20,21 @@
 # vm_size = "Standard_D8s_v4"
 
 
+# Addresses permitted to connect by SSH
+#
+# Each item of this list can be an IP address, or IP address range in CIDR
+# notation. If (and only if) the list is one element long, you can also use
+# Azure tags such as "VirtualNetwork", "Internet", or "*" (to match any IP).
+#
+# Default = ["*"]
+#
+# Example
+# ssh_addresses = [
+#   "10.0.0.0/16",
+#   "104.20.26.62"
+# ]
+
+
 # Type of storage to use
 #
 # You can find details of the storage types here:

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,7 +4,7 @@ variable "vm_size" {
 }
 
 variable "ssh_addresses" {
-  type    = list
+  type    = list(string)
   default = ["*"]
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,6 +3,11 @@ variable "vm_size" {
   default = "Standard_B2s"
 }
 
+variable "ssh_addresses" {
+  type    = list
+  default = ["*"]
+}
+
 variable "location" {
   type    = string
   default = "eastus"


### PR DESCRIPTION
<!--
Thank you for contributing!

Please complete the following sections to the best of your ability when you submit your Pull Request.
You are encouraged to keep this top level comment box updated as you develop and respond to reviews.

Note that text within html comment tags will not be rendered.
-->

### Summary
<!--
Describe the problem to be fixed or feature to be implemented in this Pull Request.
Please reference any related issue(s) and use fixes/closes keywords to automatically close them, if pertinent.
For example: "fixes #58", or "related to #238"
-->

fixes #41 

This PR implements a way to specify allowed inbound IP(s) for SSH using the NSG rules.

This has made the terraform a little messy, but might be interesting as an example of achieving if-else behaviour.
